### PR TITLE
Update README to avoid issues with Execution_Policies on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ cd stellantis-oauth-helper
 ```bash
 python -m venv .venv
 
-# Activate in PowerShell
-.venv\Scripts\Activate.ps1
+# Activate in Command Prompt
+.venv\Scripts\activate.bat
 # Activate in Linux/MacOS Bash
 source .venv/bin/activate
 


### PR DESCRIPTION
On my system, when starting .venv through Powershell I get following warning:
```
PS C:\xxx\stellantis-oauth-helper> .venv\Scripts\Activate.ps1
.venv\Scripts\Activate.ps1 : File C:\xxx\stellantis-oauth-helper\.venv\Scripts\activate.ps1 cannot be loaded because
running scripts is disabled on this system. For more information, see about_Execution_Policies at  
https:/go.microsoft.com/fwlink/?LinkID=135170.
At line:1 char:1
+ .venv\Scripts\Activate.ps1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess
```

This is easily solved by using .venv\Scripts\activate.bat in the command prompt instead.